### PR TITLE
chore(clomonitor): ignore trademark disclaimer.

### DIFF
--- a/.clomonitor.yml
+++ b/.clomonitor.yml
@@ -1,0 +1,3 @@
+exemptions:
+  - check: trademark_disclaimer
+    reason: "This is not the project website repository. No need to check for the trademark disclaimer"


### PR DESCRIPTION
## Description

Configure the CLOmonitor to ignore the trademark disclaimers required in the project website repository. This is not the website repository of the Kubewarden project.

Fix https://github.com/kubewarden/community/issues/54
