### PR TITLE
Add KubeStellar Console to adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -24,3 +24,4 @@ cncf-kubewarden-maintainers@lists.cncf.io to get involved.
 - [Foresight Mining software Corporation](https://www.foresightmining.com/)
 - [CLAAS](https://www.claas.com/)
 - [CANCOM](https://www.cancom.de/)
+- [KubeStellar Console](https://console.kubestellar.io) -- Kubernetes dashboard with a guided Kubewarden install mission


### PR DESCRIPTION
## Summary

- Adds [KubeStellar Console](https://console.kubestellar.io) to the ADOPTERS.md list
- KubeStellar Console includes a guided install mission for Kubewarden with live cluster validation, troubleshooting, and rollback support

## Context

This was discussed in kubewarden/kubewarden-controller#1561 where @jvanz suggested:

> Furthermore, if you know that some users from KubeStellar is using Kubewarden, consider asking them to add themselves in the adopters list. This will help us in the journey to the CNCF incubation level.

A companion docs PR has also been created: kubewarden/docs#726