### PR TITLE
chore(docs): Reword how to report vulnv

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,10 +50,9 @@ side, this means:
   affects them.
 
 If you have found a security vulnerability in Kubewarden, the easiest way to
-report a vulnerability is through the [Security tab on
-GitHub](https://github.com/kubewarden/community/security/advisories). This
-mechanism allows maintainers to communicate privately with you, and you do not
-need to encrypt your messages.
+report a vulnerability is through the Security tab on GitHub for the specific
+repo. This mechanism allows maintainers to communicate privately with you,
+and you don't need to encrypt your messages.
 
 Alternatively, you can can disclose it responsibly by emailing
 [cncf-kubewarden-maintainers@lists.cncf.io](mailto:cncf-kubewarden-maintainers@lists.cncf.io)


### PR DESCRIPTION


## Description

The link for "Security Tab" points to the kubewarden/community repo, which shouldn't get the advisory. For tooling automation, it is better to direct reporters to specific repos.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->


<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->

## Checklist

- [ ] I have read and understood the [Kubewarden AI Policy](https://github.com/kubewarden/community/blob/main/AI_POLICY.md)
